### PR TITLE
Ignore code blocks by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ classes
 notes.md
 .DS_Store
 reports
+clerk.build_artifacts.txt

--- a/README.md
+++ b/README.md
@@ -58,13 +58,13 @@ $ clerk -f /path/to/thing-to-lint
 CLI options:
 
 ```
-
--f, --file FILE File or dir to proofread.
--o, --output FORMAT Output type: table, EDN, or JSON.
--C, --checks List enabled checks.
--c, --config CONFIG Set temporary configuration file.
--h, --help Prints this help message.
-
+-f, --file          FILE        File or dir to proofread. 
+-o, --output        FORMAT      Output format: group, edn, json, table.
+-C, --checks                    List enabled checks.
+-c, --config        CONFIG      Set temporary configuration file.
+-h, --help                      Prints this help message.
+-b, --code-blocks               Include code blocks. 
+-v, --version                   Prints version number.
 ```
 
 Here's an example command to export results to EDN:

--- a/resources/drivel.md
+++ b/resources/drivel.md
@@ -10,6 +10,11 @@ This sentence is fine.
 
 skunked-term: This paragraph has a skunked term, hopefully.
 
+```
+This is a code block.
+It has an error error.
+```
+
 sexism: Female booksalesman is a sexist and ridiculous term.
 
 This sentence is handsome.

--- a/src/clerk/core.clj
+++ b/src/clerk/core.clj
@@ -34,11 +34,13 @@
     :validate [text/file-exists? text/file-error-msg
                conf/valid? conf/invalid-msg]]
    ["-h" "--help" "Prints this help message."]
+   ["-b" "--code-blocks" "Include code blocks." :default false]
    ["-v" "--version" "Prints version number."]])
 
 (defn clerk
   "Clerk vets a text with the supplied checks."
   [options]
+  (println "options" options)
   (->> options
        (vet/compute-or-cached)
        (ship/out)))
@@ -59,13 +61,13 @@
         version (ship/print-version)
         :else (ship/print-usage opts "You must supply an option.")))))
 
-(defn -main
-  [& args]
-  (reception args)
-  (shutdown-agents))
+;; (defn -main
+;;   [& args]
+;;   (reception args)
+;;   (shutdown-agents))
 
 ;;;; For development; prevents Cider REPL from closing.
 
-;; (defn -main
-;;   [& args]
-;;   (reception args))
+(defn -main
+  [& args]
+  (reception args))

--- a/src/clerk/core.clj
+++ b/src/clerk/core.clj
@@ -61,13 +61,13 @@
         version (ship/print-version)
         :else (ship/print-usage opts "You must supply an option.")))))
 
-;; (defn -main
-;;   [& args]
-;;   (reception args)
-;;   (shutdown-agents))
+(defn -main
+  [& args]
+  (reception args)
+  (shutdown-agents))
 
 ;;;; For development; prevents Cider REPL from closing.
 
-(defn -main
-  [& args]
-  (reception args))
+;; (defn -main
+;;   [& args]
+;;   (reception args))

--- a/src/clerk/core.clj
+++ b/src/clerk/core.clj
@@ -26,7 +26,7 @@
   [["-f" "--file FILE" "File or dir to proofread." :default nil
     :validate [text/file-exists? text/file-error-msg
                text/less-than-10-MB? text/file-size-msg]]
-   ["-o" "--output FORMAT" "Output type: group, edn, json, table"
+   ["-o" "--output FORMAT" "Output type: group, edn, json, table."
     :default "group"]
    ["-C" "--checks" "List enabled checks."]
    ["-c" "--config CONFIG" "Set temporary configuration file."
@@ -40,7 +40,6 @@
 (defn clerk
   "Clerk vets a text with the supplied checks."
   [options]
-  (println "options" options)
   (->> options
        (vet/compute-or-cached)
        (ship/out)))

--- a/src/clerk/shipping.clj
+++ b/src/clerk/shipping.clj
@@ -49,7 +49,7 @@
 
 (defn issue-str
   "Creates a simplified result string for grouped results."
-  [{:keys [line-num col-num specimen name message]}]
+  [{:keys [line-num col-num specimen message]}]
   (string/join "\t" [(str line-num ":" col-num) (str "\"" specimen "\"" " -> " message)]))
 
 (defn group-results

--- a/src/clerk/text.clj
+++ b/src/clerk/text.clj
@@ -33,7 +33,7 @@
 (defn handle-invalid-file
   [files]
   (if (empty? files) (throw (Exception. "Not a valid file"))
-  files))
+      files))
 
 ;;;; Load text and create lines to vet.
 
@@ -49,14 +49,17 @@
   (string/replace filepath (System/getProperty "user.home") "~"))
 
 (defn fetch!
-  "Loads a text and returns its lines."
-  [filepath]
-  (let [code (atom false)
-        boundary "```"
+  "Takes a code-blocks boolean and a filepath string. It loads the file
+  and returns decorated lines. Code-blocks is false by default, but
+  if true, the lines inside code blocks are kept."
+  [code-blocks filepath]
+  (let [homepath (home-path filepath)
+        code (atom false) ;; Are we in a code block?
+        boundary "```" ;; assumes code blocks are wrapped in triple backticks.
+        ;; If we see a boundry, we're either entering or exiting a code block.
         code? (fn [line] (if (string/starts-with? (:text line) boundary)
                            (assoc line :code? (swap! code not))
-                           (assoc line :code? @code)))
-        homepath (home-path filepath)]
+                           (assoc line :code? @code)))]
     (->> filepath
          slurp
          string/split-lines
@@ -67,4 +70,5 @@
                code?))
          (remove #(or (string/blank? (:text %))
                       (= boundary (:text %))
-                      (:code? %))))))
+                      (and (not code-blocks)
+                           (:code? %)))))))

--- a/src/clerk/vet.clj
+++ b/src/clerk/vet.clj
@@ -28,23 +28,23 @@
             output])
 
 (defn get-lines-from-all-files
-  [file]
+  [code-blocks file]
   (->> file
        io/file
        file-seq
        (map #(.getAbsolutePath %))
        (filter text/supported-file-type?)
        text/handle-invalid-file
-       (mapcat text/fetch!)))
+       (mapcat (partial text/fetch! code-blocks))))
 
 (defn make-input
   "Input combines user-defined options and arguments
   with the relevant cached results."
-  [{:keys [file config output]}]
+  [{:keys [file config output code-blocks]}]
   (let [c (conf/fetch-or-create! config)]
     (map->Input
      {:file file
-      :lines (get-lines-from-all-files file)
+      :lines (get-lines-from-all-files code-blocks file)
       :config c
       :checks (checks/create c)
       :cached-result (store/inventory file)

--- a/test/clerk/vet_test.clj
+++ b/test/clerk/vet_test.clj
@@ -6,7 +6,8 @@
 
 (def input (vet/make-input {:file "resources"
                             :config config-path
-                            :output "table"}))
+                            :output "table"
+                            :code-blocks false}))
 
 (def results (vet/compute input))
 

--- a/test/editors/case_recommender_test.clj
+++ b/test/editors/case_recommender_test.clj
@@ -9,6 +9,7 @@
                  "We love monday."
                  42
                  false
+                 false
                  []))
 
 (def error-line-double (text/->Line
@@ -16,12 +17,14 @@
                         "Week starts on monday, not sunday."
                         42
                         false
+                        false
                         []))
 
 (def handsome-line (text/->Line
                     "resources"
                     "This sentence looks handsome."
                     42
+                    false
                     false
                     []))
 

--- a/test/editors/existence_test.clj
+++ b/test/editors/existence_test.clj
@@ -10,6 +10,7 @@
                  "There is hopefully something wrong with this sentence."
                  42
                  false
+                 false
                  []))
 
 (def error-line-double (text/->Line
@@ -17,12 +18,14 @@
                         "There is hopefully something deceptively wrong with this sentence."
                         42
                         false
+                        false
                         []))
 
 (def handsome-line (text/->Line
                     "resources"
                     "This sentence looks handsome."
                     42
+                    false
                     false
                     []))
 

--- a/test/editors/links_test.clj
+++ b/test/editors/links_test.clj
@@ -11,6 +11,7 @@
                     "This [link](http://good.com) is working."
                     42
                     false
+                    false
                     []))
 
 (def error-line (text/->Line
@@ -18,12 +19,14 @@
                  "This [link](http://bad.com) is broken"
                  42
                  false
+                 false
                  []))
 
 (def linkless-line (text/->Line
                     "resources"
                     "This [link](not-even-a-link) is broken"
                     42
+                    false
                     false
                     []))
 

--- a/test/editors/recommender_test.clj
+++ b/test/editors/recommender_test.clj
@@ -9,6 +9,7 @@
                  "This sentence is ironical."
                  42
                  false
+                 false
                  []))
 
 (def error-line-double (text/->Line
@@ -16,12 +17,14 @@
                         "This sentence is ironical and extensible."
                         42
                         false
+                        false
                         []))
 
 (def handsome-line (text/->Line
                     "resources"
                     "This sentence looks handsome."
                     42
+                    false
                     false
                     []))
 

--- a/test/editors/repetition_test.clj
+++ b/test/editors/repetition_test.clj
@@ -10,12 +10,14 @@
                  "There is is something wrong with this this sentence."
                  42
                  false
+                 false
                  []))
 
 (def handsome-line (text/->Line
                     "resources"
                     "This sentence looks handsome."
                     42
+                    false
                     false
                     []))
 

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+## Exit if any command fails.
+set -e
+
+## Set the table.
+
+echo "Initializing build..."
+
+## Remove existing classes directory and clerk binary.
+
+echo "Removing classes directory."
+
+rm -rf classes
+
+echo "Removing .cpcache directory."
+
+rm -rf .cpcache
+
+echo "Building native image."
+
+echo "This could take a bit..."
+
+echo "If you run into issues, check out:"
+
+echo "https://github.com/clj-easy/graal-docs"
+
+clojure -M:build
+
+echo "Native image built successfully."
+
+echo "Making the clerk image executable."
+
+chmod +x clerk
+
+echo "Moving clerk binary to /usr/local/bin directory."
+
+mv clerk /usr/local/bin
+
+## Bus the table
+
+echo "Cleaning up..."
+
+rm -rf classes
+
+rm -rf .cpcache
+
+echo "Done."
+
+echo "Running clerk -h"
+
+clerk -h
+
+

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -1,49 +1,6 @@
-#!/bin/bash
-## Exit if any command fails.
-set -e
-
-## Set the table.
-
-echo "Initializing build..."
-
-## Remove existing classes directory and clerk binary.
-
-echo "Removing classes directory."
-
-rm -rf classes
-
-echo "Removing .cpcache directory."
-
-rm -rf .cpcache
-
-echo "Building native image."
-
-echo "This could take a bit..."
-
-clojure -M:build
-
-echo "Native image built successfully."
-
-echo "Making the clerk image executable."
-
-chmod +x clerk
-
 echo "Moving clerk binary to /usr/local/bin directory."
 
+echo "You may need to sudo this command."
+
 mv clerk /usr/local/bin
-
-## Bus the table
-
-echo "Cleaning up..."
-
-rm -rf classes
-
-rm -rf .cpcache
-
-echo "Done."
-
-echo "Running clerk -h"
-
-clerk -h
-
 


### PR DESCRIPTION
- Adds `-b, --code-blocks` option to explicitly include text inside codeblocks delimited by triple backticks.
- Separates build and install scripts for convenience.
